### PR TITLE
Add draggable grid lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern web application that allows you to split images into tiles and download
 - **Easy Image Upload**: Drag & drop or click to upload JPG, PNG, or WEBP images
 - **Flexible Grid Configuration**: Split images into any grid size (1x1 to 20x20)
 - **Real-time Preview**: See exactly how your image will be split with an interactive grid overlay
+- **Draggable Grid Lines**: Adjust the position of rows and columns directly in the preview
 - **Multiple Output Formats**: Export tiles as PNG (lossless) or JPG (with quality control)
 - **Batch Download**: All tiles are automatically packaged into a single ZIP file
 - **Responsive Design**: Works perfectly on desktop and mobile devices
@@ -23,15 +24,16 @@ A modern web application that allows you to split images into tiles and download
    - The image will be displayed with its dimensions
 
 2. **Configure Your Tiles**
-   - Set the number of rows and columns for your grid
+ - Set the number of rows and columns for your grid
+  - Drag the grid lines in the preview to set custom tile sizes
    - Choose output format (PNG for lossless quality, JPG for smaller file sizes)
    - For JPG format, adjust the quality slider (10-100%)
    - View the total number of tiles and individual tile dimensions
 
 3. **Preview Your Split**
-   - The preview shows your image with a grid overlay
-   - Each section represents one tile that will be created
-   - Grid lines show exactly where the image will be split
+ - The preview shows your image with a grid overlay
+ - Each section represents one tile that will be created
+  - Grid lines show exactly where the image will be split and can be dragged to adjust
 
 4. **Create and Download**
    - Click "Create Tiles & Download ZIP"

--- a/src/components/TilePreview.tsx
+++ b/src/components/TilePreview.tsx
@@ -1,14 +1,17 @@
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ImageData, TileConfig } from '@/pages/Index';
 
 interface TilePreviewProps {
   imageData: ImageData;
   config: TileConfig;
+  onConfigChange: (config: Partial<TileConfig>) => void;
 }
-
-export const TilePreview: React.FC<TilePreviewProps> = ({ imageData, config }) => {
+export const TilePreview: React.FC<TilePreviewProps> = ({ imageData, config, onConfigChange }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState<{width: number; height: number}>({ width: 0, height: 0 });
+  const [dragging, setDragging] = useState<{type: 'row'|'col'; index: number} | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -19,75 +22,101 @@ export const TilePreview: React.FC<TilePreviewProps> = ({ imageData, config }) =
 
     const img = new Image();
     img.onload = () => {
-      // Calculate display size while maintaining aspect ratio
       const maxDisplayWidth = 400;
       const maxDisplayHeight = 400;
-      
+
       let displayWidth = img.naturalWidth;
       let displayHeight = img.naturalHeight;
-      
+
       if (displayWidth > maxDisplayWidth) {
         displayHeight = (displayHeight * maxDisplayWidth) / displayWidth;
         displayWidth = maxDisplayWidth;
       }
-      
+
       if (displayHeight > maxDisplayHeight) {
         displayWidth = (displayWidth * maxDisplayHeight) / displayHeight;
         displayHeight = maxDisplayHeight;
       }
-      
+
       canvas.width = displayWidth;
       canvas.height = displayHeight;
-      
-      // Draw the image
+      setDimensions({ width: displayWidth, height: displayHeight });
+
       ctx.drawImage(img, 0, 0, displayWidth, displayHeight);
-      
-      // Draw grid overlay
-      ctx.strokeStyle = 'rgba(59, 130, 246, 0.8)';
-      ctx.lineWidth = 2;
-      
-      const tileWidth = displayWidth / config.cols;
-      const tileHeight = displayHeight / config.rows;
-      
-      // Draw vertical lines
-      for (let i = 1; i < config.cols; i++) {
-        ctx.beginPath();
-        ctx.moveTo(i * tileWidth, 0);
-        ctx.lineTo(i * tileWidth, displayHeight);
-        ctx.stroke();
-      }
-      
-      // Draw horizontal lines
-      for (let i = 1; i < config.rows; i++) {
-        ctx.beginPath();
-        ctx.moveTo(0, i * tileHeight);
-        ctx.lineTo(displayWidth, i * tileHeight);
-        ctx.stroke();
-      }
-      
-      // Draw border
-      ctx.strokeStyle = 'rgba(59, 130, 246, 1)';
-      ctx.strokeRect(0, 0, displayWidth, displayHeight);
     };
-    
+
     img.src = imageData.url;
-  }, [imageData, config]);
+  }, [imageData]);
+
+  useEffect(() => {
+    const handleMove = (e: PointerEvent) => {
+      if (!dragging || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      if (dragging.type === 'col') {
+        let pos = (e.clientX - rect.left) / rect.width;
+        const splits = [...config.colSplits];
+        const min = dragging.index === 0 ? 0.05 : splits[dragging.index - 1] + 0.05;
+        const max = dragging.index === splits.length - 1 ? 0.95 : splits[dragging.index + 1] - 0.05;
+        pos = Math.min(Math.max(pos, min), max);
+        splits[dragging.index] = pos;
+        onConfigChange({ colSplits: splits });
+      } else {
+        let pos = (e.clientY - rect.top) / rect.height;
+        const splits = [...config.rowSplits];
+        const min = dragging.index === 0 ? 0.05 : splits[dragging.index - 1] + 0.05;
+        const max = dragging.index === splits.length - 1 ? 0.95 : splits[dragging.index + 1] - 0.05;
+        pos = Math.min(Math.max(pos, min), max);
+        splits[dragging.index] = pos;
+        onConfigChange({ rowSplits: splits });
+      }
+    };
+
+    const stopDrag = () => setDragging(null);
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', stopDrag);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', stopDrag);
+    };
+  }, [dragging, config, onConfigChange]);
 
   return (
     <div className="space-y-4">
-      <div className="bg-white rounded-lg p-4 border border-slate-200">
+      <div
+        ref={containerRef}
+        className="bg-white rounded-lg p-4 border border-slate-200 relative select-none"
+      >
         <canvas
           ref={canvasRef}
           className="max-w-full border border-slate-200 rounded"
         />
+        {dimensions.width > 0 && (
+          <>
+            {config.colSplits.map((pos, i) => (
+              <div
+                key={`col-${i}`}
+                onPointerDown={() => setDragging({ type: 'col', index: i })}
+                style={{ left: `${pos * 100}%` }}
+                className="absolute top-0 bottom-0 w-1 -ml-0.5 bg-blue-500 cursor-ew-resize"
+              />
+            ))}
+            {config.rowSplits.map((pos, i) => (
+              <div
+                key={`row-${i}`}
+                onPointerDown={() => setDragging({ type: 'row', index: i })}
+                style={{ top: `${pos * 100}%` }}
+                className="absolute left-0 right-0 h-1 -mt-0.5 bg-blue-500 cursor-ns-resize"
+              />
+            ))}
+            <div className="absolute inset-0 border border-blue-500 pointer-events-none" />
+          </>
+        )}
       </div>
-      
+
       <div className="text-sm text-slate-600 space-y-1">
         <p>Original: {imageData.width}x{imageData.height}px</p>
         <p>Grid: {config.rows}x{config.cols} ({config.rows * config.cols} tiles)</p>
-        <p>
-          Each tile: {Math.floor(imageData.width / config.cols)}x{Math.floor(imageData.height / config.rows)}px
-        </p>
       </div>
     </div>
   );

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -29,33 +29,42 @@ export const createTilesZip = async (imageData: ImageData, config: TileConfig): 
           throw new Error('Failed to get canvas context');
         }
         
-        const tileWidth = Math.floor(img.naturalWidth / config.cols);
-        const tileHeight = Math.floor(img.naturalHeight / config.rows);
-        
-        // Security check: Validate tile dimensions
-        if (tileWidth < 1 || tileHeight < 1) {
-          throw new Error('Calculated tile dimensions are too small. Please reduce the number of rows or columns.');
-        }
-        
-        canvas.width = tileWidth;
-        canvas.height = tileHeight;
-        
+        const rowPositions = [0, ...config.rowSplits, 1];
+        const colPositions = [0, ...config.colSplits, 1];
+
         let tileIndex = 1;
-        
-        for (let row = 0; row < config.rows; row++) {
-          for (let col = 0; col < config.cols; col++) {
+
+        for (let r = 0; r < config.rows; r++) {
+          const srcY = Math.floor(rowPositions[r] * img.naturalHeight);
+          const nextY = Math.floor(rowPositions[r + 1] * img.naturalHeight);
+          const tileHeight = nextY - srcY;
+
+          for (let c = 0; c < config.cols; c++) {
+            const srcX = Math.floor(colPositions[c] * img.naturalWidth);
+            const nextX = Math.floor(colPositions[c + 1] * img.naturalWidth);
+            const tileWidth = nextX - srcX;
+
+            if (tileWidth < 1 || tileHeight < 1) {
+              throw new Error('Calculated tile dimensions are too small. Adjust grid lines.');
+            }
+
+            canvas.width = tileWidth;
+            canvas.height = tileHeight;
+
             // Clear canvas
             ctx.clearRect(0, 0, tileWidth, tileHeight);
-            
-            // Calculate source coordinates
-            const srcX = col * tileWidth;
-            const srcY = row * tileHeight;
-            
+
             // Draw the tile
             ctx.drawImage(
               img,
-              srcX, srcY, tileWidth, tileHeight,
-              0, 0, tileWidth, tileHeight
+              srcX,
+              srcY,
+              tileWidth,
+              tileHeight,
+              0,
+              0,
+              tileWidth,
+              tileHeight
             );
             
             // Convert to blob with validation


### PR DESCRIPTION
## Summary
- let users drag grid lines to create custom tile sizes
- accept custom row/column split positions
- update README with instructions

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_b_683ef0b66b60833287f6e595b978d094