### PR TITLE
Increase max image resolution and warn when oversize

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This application works in all modern browsers that support:
 
 ## Limitations
 
-- Maximum recommended image size: 4096x4096 pixels (browser dependent)
+- Maximum allowed image size: 8192x8192 pixels (images larger than 4096x4096 will trigger a warning)
 - Maximum grid size: 20x20 tiles
 - Supported formats: JPG, PNG, WEBP input; PNG, JPG output
 - Requires modern browser with Canvas API support

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { Upload, Image as ImageIcon, AlertTriangle } from 'lucide-react';
 import { ImageData } from '@/pages/Index';
 import { validateImageFile } from '@/utils/security';
+import { toast } from '@/components/ui/use-toast';
 
 interface ImageUploaderProps {
   onImageUpload: (imageData: ImageData) => void;
@@ -12,6 +13,7 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload }) =
   const [isDragging, setIsDragging] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const SAFE_DIMENSION = 4096;
 
   const handleImageLoad = useCallback(async (file: File) => {
     setIsLoading(true);
@@ -30,6 +32,14 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload }) =
       const img = new Image();
       
       img.onload = () => {
+        if (img.naturalWidth > SAFE_DIMENSION || img.naturalHeight > SAFE_DIMENSION) {
+          toast({
+            title: 'Large Image Warning',
+            description: `Dimensions exceed ${SAFE_DIMENSION}x${SAFE_DIMENSION}. Processing may be unstable.`,
+            variant: 'destructive'
+          });
+        }
+
         onImageUpload({
           file,
           url,

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -3,7 +3,7 @@ import JSZip from 'jszip';
 import { ImageData, TileConfig } from '@/pages/Index';
 
 // Maximum canvas size to prevent memory issues
-const MAX_CANVAS_SIZE = 4096;
+const MAX_CANVAS_SIZE = 8192;
 
 export const createTilesZip = async (imageData: ImageData, config: TileConfig): Promise<void> => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- allow images up to 8192x8192 for tiling
- warn users via toast when uploaded image exceeds 4096x4096
- update docs about new size limit

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68419487199c833299ceba0da4c3fa46