### PR TITLE
Warn about large uploads

### DIFF
--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -28,6 +28,14 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload }) =
         return;
       }
 
+      if (validation.warning) {
+        toast({
+          title: 'Large File Warning',
+          description: validation.warning,
+          variant: 'destructive'
+        });
+      }
+
       const url = URL.createObjectURL(file);
       const img = new Image();
       
@@ -127,7 +135,7 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload }) =
                 {isDragging ? 'Drop your image here' : 'Upload an image'}
               </p>
               <p className="text-sm text-slate-500">
-                Drag & drop or click to select • JPG, PNG, WEBP • Max 50MB
+                Drag & drop or click to select • JPG, PNG, WEBP
               </p>
             </div>
           </div>

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,5 +1,5 @@
 
-// Maximum file size in bytes (50MB)
+// Recommended maximum file size in bytes (50MB)
 export const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 // Allowed MIME types
@@ -26,13 +26,14 @@ const FILE_SIGNATURES: Record<string, number[][]> = {
 export interface FileValidationResult {
   isValid: boolean;
   error?: string;
+  warning?: string;
 }
 
 export const validateFileSize = (file: File): FileValidationResult => {
   if (file.size > MAX_FILE_SIZE) {
     return {
-      isValid: false,
-      error: `File size exceeds maximum allowed size of ${Math.round(MAX_FILE_SIZE / (1024 * 1024))}MB`
+      isValid: true,
+      warning: `File size exceeds ${Math.round(MAX_FILE_SIZE / (1024 * 1024))}MB. Processing may be slow.`
     };
   }
   return { isValid: true };
@@ -91,7 +92,7 @@ export const validateImageFile = async (file: File): Promise<FileValidationResul
   if (!sizeValidation.isValid) {
     return sizeValidation;
   }
-  
+
   // Check MIME type
   const mimeValidation = validateMimeType(file);
   if (!mimeValidation.isValid) {
@@ -103,6 +104,10 @@ export const validateImageFile = async (file: File): Promise<FileValidationResul
   if (!signatureValidation.isValid) {
     return signatureValidation;
   }
-  
+
+  if (sizeValidation.warning) {
+    return { isValid: true, warning: sizeValidation.warning };
+  }
+
   return { isValid: true };
 };


### PR DESCRIPTION
## Summary
- allow uploading images bigger than 50MB
- show a toast warning when uploaded image is over 50MB
- update drag-drop hint to remove max file size

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6846b1956d7c8332b6097d8314a45ba5