### PR TITLE
Remove image size restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ This application works in all modern browsers that support:
 
 ## Limitations
 
-- Maximum allowed image size: 8192x8192 pixels (images larger than 4096x4096 will trigger a warning)
 - Maximum grid size: 20x20 tiles
 - Supported formats: JPG, PNG, WEBP input; PNG, JPG output
 - Requires modern browser with Canvas API support

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -13,7 +13,6 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload }) =
   const [isDragging, setIsDragging] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const SAFE_DIMENSION = 4096;
 
   const handleImageLoad = useCallback(async (file: File) => {
     setIsLoading(true);
@@ -38,15 +37,8 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUpload }) =
 
       const url = URL.createObjectURL(file);
       const img = new Image();
-      
+
       img.onload = () => {
-        if (img.naturalWidth > SAFE_DIMENSION || img.naturalHeight > SAFE_DIMENSION) {
-          toast({
-            title: 'Large Image Warning',
-            description: `Dimensions exceed ${SAFE_DIMENSION}x${SAFE_DIMENSION}. Processing may be unstable.`,
-            variant: 'destructive'
-          });
-        }
 
         onImageUpload({
           file,

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -2,20 +2,12 @@
 import JSZip from 'jszip';
 import { ImageData, TileConfig } from '@/pages/Index';
 
-// Maximum canvas size to prevent memory issues
-const MAX_CANVAS_SIZE = 8192;
-
 export const createTilesZip = async (imageData: ImageData, config: TileConfig): Promise<void> => {
   return new Promise((resolve, reject) => {
     const img = new Image();
     
     img.onload = async () => {
       try {
-        // Security check: Validate image dimensions
-        if (img.naturalWidth > MAX_CANVAS_SIZE || img.naturalHeight > MAX_CANVAS_SIZE) {
-          throw new Error(`Image dimensions too large. Maximum allowed size is ${MAX_CANVAS_SIZE}x${MAX_CANVAS_SIZE} pixels.`);
-        }
-        
         // Security check: Validate tile configuration
         if (config.rows < 1 || config.rows > 20 || config.cols < 1 || config.cols > 20) {
           throw new Error('Invalid tile configuration. Rows and columns must be between 1 and 20.');


### PR DESCRIPTION
## Summary
- drop documentation of the 8192x8192 max image limitation
- remove warning for images larger than 4096x4096
- delete the hard-coded canvas dimension check

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684832179544833296d8d23cc5e9d606